### PR TITLE
Add sound card for each sound entry in the app

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -6,6 +6,7 @@ declare module '@rebass/preset';
 
 // read about the audio features here: https://meyda.js.org/audio-features
 interface Sound {
+    _id?: string;
     chroma?: number[];
     filename: string;
     instrument?: string;

--- a/main/background.ts
+++ b/main/background.ts
@@ -1,4 +1,4 @@
-import { app } from 'electron';
+import { app, protocol } from 'electron';
 import serve from 'electron-serve';
 
 import createWindow from './create-window';
@@ -33,4 +33,16 @@ if (isProd) {
 
 app.on('window-all-closed', () => {
     app.quit();
+});
+
+app.on('ready', async () => {
+    const protocolName = 'audio';
+    protocol.registerFileProtocol(protocolName, (request, callback) => {
+        const url = request.url.replace(`${protocolName}://`, '');
+        try {
+            return callback(decodeURIComponent(url));
+        } catch (error) {
+            console.error(error);
+        }
+    });
 });

--- a/main/db/sounds.ts
+++ b/main/db/sounds.ts
@@ -21,6 +21,14 @@ class Sounds {
         const result = await this.db.find(query);
         return result as any;
     }
+
+    async clear() {
+        await this.db.remove({}, { multi: true }, (err, numRemoved) => {
+            this.db.loadDatabase((err) => {
+                if (err) console.log(err);
+            });
+        });
+    }
 }
 
 const sounds = new Sounds();

--- a/main/ipc/ClearSoundsChannel.ts
+++ b/main/ipc/ClearSoundsChannel.ts
@@ -1,0 +1,19 @@
+import { IpcMainEvent } from 'electron';
+
+import Channel from './Channel';
+import db from '../db';
+
+export default class ClearSoundsChannel extends Channel {
+    /**
+     * Clears all sounds from the DB
+     * @param event
+     * @param request { responseChannel, params: [DB query object] }
+     */
+    async handler(event: IpcMainEvent, request: IPCRequest) {
+        console.log('ClearSoundsChannel request: ', request.params);
+        const responseChannel = this.getResponseChannel(request);
+        let reply: IPCResponse = {};
+        await db.sounds.clear();
+        event.sender.send(responseChannel, JSON.stringify(reply));
+    }
+}

--- a/main/ipc/index.ts
+++ b/main/ipc/index.ts
@@ -2,9 +2,14 @@ import { ipcMain } from 'electron';
 
 import Channel from './Channel';
 import FetchSoundsChannel from './FetchSoundsChannel';
+import ClearSoundsChannel from './ClearSoundsChannel';
 import InsertSoundChannel from './InsertSoundChannel';
 
-const channels: Channel[] = [new FetchSoundsChannel('fetch_sounds'), new InsertSoundChannel('insert_sound')];
+const channels: Channel[] = [
+    new FetchSoundsChannel('fetch_sounds'),
+    new ClearSoundsChannel('clear_sounds'),
+    new InsertSoundChannel('insert_sound'),
+];
 
 export function registerIpcChannels() {
     console.log('Registering IPC Channels');

--- a/renderer/components/sample.tsx
+++ b/renderer/components/sample.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Box, Text } from 'rebass';
+import getFileName from '../../util/getFileName';
+
+const Sample = ({ sound }: { sound: Sound }) => {
+    const { filename: path } = sound;
+    const filename = getFileName(path);
+    return (
+        <Box p={3} sx={{ borderRadius: '3px' }} bg='primary'>
+            <Text my={2} color='secondary' fontWeight='bold' fontSize={[2, 3]}>
+                {filename}
+            </Text>
+            <Box my={3}>
+                <Text my={2} color='secondary' fontSize={[1, 2]}>
+                    Loudness: {sound.loudness.total.toFixed(2)}
+                </Text>
+                <Text my={2} color='secondary' fontSize={[1, 2]}>
+                    Centroid: {sound.spectralCentroid.toFixed(2)}
+                </Text>
+                <Text my={2} color='secondary' fontSize={[1, 2]}>
+                    Flatness: {sound.spectralFlatness.toFixed(4)}
+                </Text>
+                <Text my={2} color='secondary' fontSize={[1, 2]}>
+                    Kurtosis: {sound.spectralKurtosis.toFixed(2)}
+                </Text>
+            </Box>
+            <audio controls>
+                <source src={`audio://${path}`} />
+            </audio>
+        </Box>
+    );
+};
+
+export default Sample;

--- a/renderer/components/samples.tsx
+++ b/renderer/components/samples.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box } from 'rebass';
+import Sample from './sample';
+
+const Samples = ({ sounds = [] }: { sounds: Sound[] }) => (
+    <Box my={3} sx={{ display: 'grid', gridGap: 3, gridTemplateColumns: 'repeat(auto-fill, minmax(450px, 1fr))' }}>
+        {sounds.map((sound) => (
+            <Sample sound={sound} key={sound._id} />
+        ))}
+    </Box>
+);
+
+export default Samples;

--- a/renderer/components/select-folder.tsx
+++ b/renderer/components/select-folder.tsx
@@ -1,23 +1,29 @@
 import React from 'react';
-import { Box } from 'rebass';
-import { css } from '@emotion/core';
+import { Box, Button } from 'rebass';
+import styled from '@emotion/styled';
 
-const text = css`
-    color: #fff;
+const Hidden = styled.div`
+    display: none;
 `;
 
 const SelectFolder = ({ onChange }) => {
     const handleFile = (e) => {
         const { files } = e.target;
         const [head] = files;
+        if (!head) return;
         const { path, webkitRelativePath: relPath } = head;
         const folder = [path.substring(0, path.indexOf(relPath) - 1), relPath.split('/')[0]].join('/');
         onChange(folder);
     };
     const onlyFolders = { webkitdirectory: '', multiple: '' };
     return (
-        <Box sx={{ my: 3 }}>
-            <input css={text} type='file' onChange={handleFile} {...(onlyFolders as any)} />
+        <Box sx={{ my: 3, position: 'relative' }} display='inline'>
+            <Button sx={{ fontSize: 2, fontFamily: 'Arial' }} htmlFor='file-select' as='label' variant='primary' mr={2}>
+                Add Sounds
+            </Button>
+            <Hidden>
+                <input id='file-select' type='file' onChange={handleFile} {...(onlyFolders as any)} />
+            </Hidden>
         </Box>
     );
 };

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -1,10 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
+import { Global, css } from '@emotion/core';
 import { ThemeProvider } from 'emotion-theming';
 import type { AppProps } from 'next/app';
 
 import IpcService, { IpcContext } from '../services/IpcService';
 import theme from '../theme';
+
+const global = css`
+    body {
+        background: ${theme.colors.background};
+    }
+`;
 
 const Main = styled.main`
     font-family: 'system-ui', sans-serif;
@@ -21,6 +28,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
     return (
         <ThemeProvider theme={theme}>
             <IpcContext.Provider value={ipcService}>
+                <Global styles={global} />
                 <Main>
                     <Component {...pageProps} />
                 </Main>

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -1,27 +1,44 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import Head from 'next/head';
 import { Button, Heading, Text } from 'rebass';
 
 import SelectFolder from '../components/select-folder';
+import Samples from '../components/samples';
 import useIpcService from '../hooks/useIpcService';
 
 export default function Home() {
     const ipcService = useIpcService();
     const [folder, setFolder] = useState();
-
-    const analyze = async () => {
+    const [sounds, setSounds] = useState<Sound[]>([]);
+    useEffect(() => {
+        if (!ipcService) return;
+        reloadSounds();
+    }, [ipcService]);
+    const clear = async () => {
+        if (!ipcService) return;
+        await ipcService.clearSounds();
+        reloadSounds();
+    };
+    const analyze = async (folder) => {
         if (!ipcService) return;
         console.log('analyze');
         await ipcService.analyze(folder);
     };
-
     const getSounds = async () => {
         if (!ipcService) return;
         console.log('getSounds');
-        const sounds = await ipcService.getSounds({});
-        console.log(sounds);
+        const { results } = await ipcService.getSounds({});
+        console.log(results);
+        return results;
     };
-
+    const reloadSounds = useCallback(async () => {
+        const sounds = await getSounds();
+        setSounds(sounds);
+    }, [setSounds, getSounds]);
+    const onSelect = async (path) => {
+        await analyze(path);
+        reloadSounds();
+    };
     return (
         <>
             <Head>
@@ -31,14 +48,13 @@ export default function Home() {
                 <Heading fontSize={[6, 7, 8]} color='primary' fontWeight='800'>
                     Soundboy
                 </Heading>
-                <Button variant='primary' mr={2} onClick={analyze}>
-                    Analyze
-                </Button>
-                <Button variant='primary' mr={2} onClick={getSounds}>
-                    Get Sounds
-                </Button>
-                <SelectFolder onChange={setFolder} />
-                {!!folder && <Text color='primary'>You have selected {folder} as your folder</Text>}
+                {sounds.length > 0 && (
+                    <Button onClick={clear} variant='primary' mr={2}>
+                        Clear Sounds
+                    </Button>
+                )}
+                <SelectFolder onChange={onSelect} />
+                <Samples sounds={sounds} />
             </div>
         </>
     );

--- a/renderer/services/IpcService.ts
+++ b/renderer/services/IpcService.ts
@@ -70,8 +70,12 @@ export default class IpcService {
         return stream;
     }
 
+    async clearSounds() {
+        await this.fetch('clear_sounds', {});
+    }
+
     async analyze(folder: string, callback?: (data: IPCResponse) => void) {
-        analyzeSounds(folder, async (data: IPCResponse) => {
+        await analyzeSounds(folder, async (data: IPCResponse) => {
             if (data.error) {
                 console.error(`Error analyzing '${data.result?.filename}'`);
                 console.error(data.error);

--- a/renderer/theme.ts
+++ b/renderer/theme.ts
@@ -4,6 +4,7 @@ const mTheme = {
     ...theme,
     colors: {
         ...theme.colors,
+        secondary: '#360858',
         blue: '#07c',
         lightgray: '#f6f6ff',
         primary: '#73e',

--- a/util/getFileName.ts
+++ b/util/getFileName.ts
@@ -1,0 +1,5 @@
+export default (path) => {
+    const i = path.lastIndexOf('/');
+    if (i <= -1) return path;
+    return path.substring(i + 1, path.length);
+};


### PR DESCRIPTION
Adds a sound card which shows every entry loaded into the app.

Sounds entries can be added with the `Add Sounds` button and cleared with the `Clear Sounds` button.

Each sound card has an audio player and shows some
stats from the audio feature extraction.

![sound](https://user-images.githubusercontent.com/7284672/95826505-43d5dd00-0ce7-11eb-84eb-94cf513c4dff.gif)

Upon re-opening the app, all sounds in the database will be loaded.