### PR TITLE
Improve audio player & slider behavior

### DIFF
--- a/renderer/components/audio-player/main-audio-player.tsx
+++ b/renderer/components/audio-player/main-audio-player.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Box, Flex } from 'rebass';
 import { Text } from 'rebass';
 import AudioPlayer from './audio-player';
@@ -14,9 +14,23 @@ const MainAudioPlayer = () => {
     const input = useRef();
     const { dispatch, state } = useAppState();
     const { nowPlaying } = state.sounds;
-    const pause = () => nowPlaying?.audio.playPause();
     const playing = !!nowPlaying?.playing;
-    if (!nowPlaying) return null;
+    const audio = nowPlaying?.audio;
+    const pause = () => audio?.playPause();
+    useEffect(() => {
+        if (typeof document === 'undefined') return;
+        const onKeyDown = (e) => {
+            if (e.code === 'Space') {
+                e.preventDefault();
+                pause();
+            }
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [audio]);
+    if (!nowPlaying || !nowPlaying.sound) return null;
     const filename = getFileName(nowPlaying.sound.filename);
     return (
         <Box sx={{ flex: '1', minWidth: '200px', marginTop: 3, marginBottom: 4 }}>

--- a/renderer/state/reducer.ts
+++ b/renderer/state/reducer.ts
@@ -122,8 +122,8 @@ function playSound(state: State, action: Action): State {
 
 function stopSound(state: State, action: Action): State {
     const prevTrack = toNowPlaying(action.payload);
-    const { audio, sound } = state.sounds.nowPlaying || {};
-    const nowPlaying = prevTrack;
+    const nowPlaying = state.sounds.nowPlaying;
+    const { audio, sound } = nowPlaying;
     if (audio && prevTrack.sound?._id === sound?._id) {
         nowPlaying.playing = false;
     }


### PR DESCRIPTION
This commit addresses a few things to make audio playback feel and sound better.

The first of which is it fixes a bug where multiple samples can be played at the same time.  This was a mistake in the audio pause state reducer.

Additionally, the audio slider is now properly debounced and will only skip ahead once the slider is released.	Prior to this it would
update whenever the mouse button was held leading to weird audio artifacts.

Also pressing the spacebar will now pause/play the selected audio track.