### PR TITLE
More audio player fixes

### DIFF
--- a/renderer/components/audio-player/wave-surfer.tsx
+++ b/renderer/components/audio-player/wave-surfer.tsx
@@ -70,7 +70,15 @@ const withWave = (Component) => {
                 setPlaying(false);
             });
             return () => {
-                audio.stop();
+                try {
+                    audio.stop();
+                } catch (e) {
+                    // The case this fails is when WaveSurfer
+                    // tires to seek the audio to NaN.
+                    // We are destroying the audio in the next line
+                    // which should make sure its cleaned up.
+                    console.log(e);
+                }
                 if (onStop) onStop({ audio, sound });
                 audio.destroy();
             };

--- a/renderer/state/reducer.ts
+++ b/renderer/state/reducer.ts
@@ -90,6 +90,7 @@ function fetchSoundsResponse(state: State, action: Action): State {
     return {
         ...state,
         sounds: {
+            ...state.sounds,
             data: action.payload.results,
             error: action.payload.error,
             fetching: false,
@@ -123,7 +124,8 @@ function playSound(state: State, action: Action): State {
 function stopSound(state: State, action: Action): State {
     const prevTrack = toNowPlaying(action.payload);
     const nowPlaying = state.sounds.nowPlaying;
-    const { audio, sound } = nowPlaying;
+    const audio = nowPlaying?.audio;
+    const sound = nowPlaying?.sound;
     if (audio && prevTrack.sound?._id === sound?._id) {
         nowPlaying.playing = false;
     }


### PR DESCRIPTION
Prevents WaveSurfer from crashing due to seeking to NaN as we remove the audio.

Additionally makes sure that the nowPlaying value is preserved when some values are updated.