### PR TITLE
Paginate samples into pages

### DIFF
--- a/renderer/components/analyzer-status.tsx
+++ b/renderer/components/analyzer-status.tsx
@@ -11,7 +11,7 @@ import Card from './card';
 import Clickable from './clickable';
 
 const Container = styled(Card)`
-    margin-top: 10px;
+    margin-top: 22px;
 `;
 
 const ProgressContainer = styled(Box)`

--- a/renderer/components/audio-player/audio-player.tsx
+++ b/renderer/components/audio-player/audio-player.tsx
@@ -26,16 +26,19 @@ const WaveForm = withWave(
 
 const AudioPlayer = ({
     sound,
+    contentColor: initialContentColor,
     waveColor: initialWaveColor,
     progressColor: initialProgressColor,
 }: {
     sound: Sound;
     waveColor?: string;
     progressColor?: string;
+    contentColor?: string;
 }) => {
     const { dispatch } = useAppState();
     const theme = useTheme();
-    const waveColor = initialWaveColor || theme.colors.white;
+    const contentColor = initialContentColor || theme.colors.black;
+    const waveColor = initialWaveColor || theme.colors.grey;
     const progressColor = initialProgressColor || theme.colors.accent;
     const { filename: path } = sound;
     const filename = getFileName(path);
@@ -61,12 +64,7 @@ const AudioPlayer = ({
     };
     return (
         <WaveContainer>
-            <WaveForm sound={sound} options={options} waveColor={waveColor} />
-            {!!filename && (
-                <Text mx={1} my={2} color={waveColor} fontStyle='italic' fontSize={[1, 2]}>
-                    {filename}
-                </Text>
-            )}
+            <WaveForm sound={sound} options={options} waveColor={contentColor} />
         </WaveContainer>
     );
 };

--- a/renderer/components/audio-player/main-audio-player.tsx
+++ b/renderer/components/audio-player/main-audio-player.tsx
@@ -33,7 +33,7 @@ const MainAudioPlayer = () => {
     if (!nowPlaying || !nowPlaying.sound) return null;
     const filename = getFileName(nowPlaying.sound.filename);
     return (
-        <Box sx={{ flex: '1', minWidth: '200px', marginTop: 3, marginBottom: 4 }}>
+        <Box sx={{ flex: '1', minWidth: '200px', marginTop: 3 }}>
             <Card>
                 <Text mx={1} my={2} color='black' fontWeight='bold' fontSize={[1, 2]}>
                     {filename}

--- a/renderer/components/card.tsx
+++ b/renderer/components/card.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Heading } from 'rebass';
 import Clickable from './clickable';
 import type { Url } from '../../@types';
+import useTheme from '../hooks/useTheme';
 
 const Card = ({
     title,
@@ -18,6 +19,7 @@ const Card = ({
     children?: React.ReactNode;
     className?: string;
 }) => {
+    const theme = useTheme();
     let activeStyle = {};
     const clickable = typeof href !== 'undefined' || typeof onClick === 'function';
     if (clickable) {
@@ -31,7 +33,7 @@ const Card = ({
         borderWidth: '1px',
         borderColor: 'grey',
         borderStyle: 'solid',
-        boxShadow: '-4px 4px 50px -12px rgb(185 185 185 / 56%)',
+        boxShadow: theme.shadows.normal,
         '&:active': {
             ...activeStyle,
         },

--- a/renderer/components/clickable.tsx
+++ b/renderer/components/clickable.tsx
@@ -17,11 +17,13 @@ const Clickable = ({
     href,
     onClick,
     className,
+    disabled,
 }: {
     children: React.ReactNode;
     href?: Url;
     onClick?: () => void;
     className?: string;
+    disabled?: boolean;
 }) => {
     const isLink = typeof href !== 'undefined';
     const isButton = typeof onClick === 'function';
@@ -29,7 +31,7 @@ const Clickable = ({
         return <div className={className}>{children}</div>;
     }
     const Wrapper = isLink ? Link : Button;
-    const props = isLink ? { href } : { onClick };
+    const props = isLink ? { href } : { disabled, onClick };
     return <Wrapper {...props}>{children}</Wrapper>;
 };
 

--- a/renderer/components/header.tsx
+++ b/renderer/components/header.tsx
@@ -19,7 +19,7 @@ const Position = styled.div`
 `;
 
 const Header = () => (
-    <Heading fontSize={[7, 8]} color='black' fontStyle='italic' fontWeight='800'>
+    <Heading sx={{ userSelect: 'none' }} fontSize={[7, 8]} color='black' fontStyle='italic' fontWeight='800'>
         <Flex sx={{ position: 'relative' }} alignItems='center'>
             <Box sx={{ letterSpacing: '-10px' }}>Soundboy</Box>
             <Box width='150px' sx={{ position: 'relative' }}>

--- a/renderer/components/icon-button.tsx
+++ b/renderer/components/icon-button.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Clickable from './clickable';
+import styled from '@emotion/styled';
+
+import type { Theme } from '../theme';
+
+const Wrapper = styled.div<{ disabled?: boolean }>`
+    display: flex;
+    align-items: center;
+    ${(props) =>
+        props.disabled &&
+        `
+    opacity: 0.3;
+    cursor: auto;
+  `}
+
+    svg {
+        height: 25px;
+        width: 25px;
+    }
+
+    ${({ theme }: { theme: Theme }) =>
+        theme &&
+        `
+    @media screen and (min-width: ${theme.breakpoints[0]}) {
+      svg {
+          height: 40px;
+          width: 40px;
+      }
+    }
+  `}
+`;
+
+const IconButton = ({
+    children,
+    onClick,
+    disabled,
+}: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+}) => {
+    return (
+        <Clickable onClick={onClick} disabled={disabled}>
+            <Wrapper disabled={disabled}>{children}</Wrapper>
+        </Clickable>
+    );
+};
+
+export default IconButton;

--- a/renderer/components/list.tsx
+++ b/renderer/components/list.tsx
@@ -1,21 +1,64 @@
 import React from 'react';
-import { Box, Text } from 'rebass';
+import { Flex, Box, Text } from 'rebass';
 import Stack from './stack';
+import Card from './card';
+import Sample from './sample';
+import { Sound } from '../../@types';
+import IconButton from './icon-button';
+import { GrFormPrevious, GrFormNext } from 'react-icons/gr';
+import AnalyzerStatus from './analyzer-status';
+import { GiSoundOn } from 'react-icons/gi';
 
-const List = ({ title, children }: { title: string; children: React.ReactNode }) => {
+const SOUNDS_PER_PAGE = 6;
+
+const List = ({
+    title,
+    sounds,
+    page,
+    onPageChange,
+}: {
+    title: string;
+    sounds: Sound[];
+    page: number;
+    onPageChange: (any) => void;
+}) => {
+    const lastPage = Math.ceil(sounds.length / SOUNDS_PER_PAGE) || 1;
+    const hasManyPages = lastPage > 1;
     return (
-        <Box sx={{ borderRadius: '7px', width: '100%', minHeight: '700px' }} bg='darkGrey'>
-            <Box
-                sx={{ borderTopLeftRadius: '7px', borderTopRightRadius: '7px', marginBottom: '50px' }}
-                px={3}
-                py={4}
-                bg='primary'
-            >
-                <Text color='white' fontWeight='bold' fontSize={[2, 3]}>
-                    {title}
-                </Text>
-            </Box>
-            <Stack>{children}</Stack>
+        <Box sx={{ borderRadius: '7px', width: '100%', minHeight: '700px' }}>
+            <Flex justifyContent='space-between' marginLeft={2} px={3} marginTop={4} marginBottom={1}>
+                <Flex flexDirection='column'>
+                    <Text color='black' fontWeight='bold' fontSize={[3, 4]}>
+                        <Flex alignItems='center' sx={{ '> svg': { marginBottom: '2px', marginLeft: '8px' } }}>
+                            {title} <GiSoundOn size='40px' />
+                        </Flex>
+                    </Text>
+                    <Text
+                        sx={{ visibility: hasManyPages ? 'visible' : 'hidden' }}
+                        color='black'
+                        fontStyle='italic'
+                        fontSize={[1]}
+                    >
+                        {`Page ${page} of ${lastPage}`}
+                    </Text>
+                </Flex>
+                {hasManyPages && (
+                    <Box>
+                        <IconButton disabled={page <= 1} onClick={() => onPageChange((page) => page - 1)}>
+                            <GrFormPrevious />
+                        </IconButton>
+                        <IconButton disabled={page >= lastPage} onClick={() => onPageChange((page) => page + 1)}>
+                            <GrFormNext />
+                        </IconButton>
+                    </Box>
+                )}
+            </Flex>
+            <Stack>
+                <AnalyzerStatus />
+                {sounds.slice((page - 1) * SOUNDS_PER_PAGE, page * SOUNDS_PER_PAGE).map((sound) => (
+                    <Sample sound={sound} key={sound._id} />
+                ))}
+            </Stack>
         </Box>
     );
 };

--- a/renderer/components/sample.tsx
+++ b/renderer/components/sample.tsx
@@ -1,20 +1,50 @@
 import React from 'react';
-import { Box } from 'rebass';
+import { Text, Box } from 'rebass';
 
 import { Sound } from '../../@types';
 import { AudioPlayer } from './audio-player';
+import useTheme from '../hooks/useTheme';
+import Stack from './stack';
+import getFileName from '../../util/getFileName';
 
 const Sample = ({ sound }: { sound: Sound }) => {
+    const theme = useTheme();
+    const { filename: path } = sound;
+    const filename = getFileName(path);
     return (
-        <Box
-            paddingRight={2}
-            marginLeft={2}
-            my={1}
-            bg='medGrey'
-            sx={{ borderTopLeftRadius: '7px', borderBottomLeftRadius: '7px', border: '1px solid #7d7e80' }}
-        >
-            <AudioPlayer sound={sound} />
-        </Box>
+        <Stack>
+            {!!filename && (
+                <Text
+                    sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
+                    mx={1}
+                    marginTop={2}
+                    color={'black'}
+                    fontStyle='italic'
+                    opacity={0.8}
+                    fontWeight='bold'
+                    textAlign='right'
+                    fontSize={[1, 2]}
+                >
+                    {filename}
+                </Text>
+            )}
+            <Box
+                paddingRight={2}
+                marginLeft={2}
+                my={1}
+                bg='white'
+                sx={{
+                    borderTopLeftRadius: '7px',
+                    borderBottomLeftRadius: '7px',
+                    borderWidth: '1px',
+                    borderStyle: 'solid',
+                    borderColor: 'grey',
+                    boxShadow: theme.shadows.normal,
+                }}
+            >
+                <AudioPlayer sound={sound} />
+            </Box>
+        </Stack>
     );
 };
 

--- a/renderer/components/stack.tsx
+++ b/renderer/components/stack.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Flex } from 'rebass';
 
-const Stack = ({ children }: { children: React.ReactNode }) => {
+const Stack = ({ children, marginLeft }: { children: React.ReactNode; marginLeft?: number }) => {
     return (
-        <Flex sx={{ width: '100%' }} flexDirection='column'>
+        <Flex sx={{ width: '100%' }} flexDirection='column' marginLeft={marginLeft}>
             {children}
         </Flex>
     );

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -12,6 +12,7 @@ import theme from '../theme';
 const global = css`
     body {
         background: ${theme.colors.background};
+        margin: 0;
     }
 `;
 

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -3,7 +3,6 @@ import Head from 'next/head';
 import { Button, Flex, Box } from 'rebass';
 
 import Header from '../components/header';
-import AnalyzerStatus from '../components/analyzer-status';
 import SelectFolder from '../components/select-folder';
 import Samples from '../components/samples';
 import Groups from '../components/groups';
@@ -68,7 +67,6 @@ function Home() {
                         <MainAudioPlayer />
                     </Flex>
                 </Box>
-                <AnalyzerStatus />
                 <Samples />
             </div>
         </>

--- a/renderer/theme.ts
+++ b/renderer/theme.ts
@@ -15,7 +15,10 @@ const mTheme = {
         blue: '#07c',
         lightgray: '#f6f6ff',
         primary: '#1d53ff',
-        accent: '#f72f5a',
+        accent: '#1f83ed',
+    },
+    shadows: {
+        normal: '-4px 4px 50px -12px rgb(185 185 185 / 56%)',
     },
 };
 


### PR DESCRIPTION
Paginates the samples into pages to ensure the UI is not cluttered and slow
when dealing with large sample libraries.

Each page shows 6 samples per page and each sample category now shows
how many pages are present with buttons to navigate between them.

Also updates the UI to use a simpler design with 'floating' cards.

![1](https://user-images.githubusercontent.com/7284672/98863325-0d41ce00-241d-11eb-832c-22c99a36c158.png)

![2](https://user-images.githubusercontent.com/7284672/98863454-424e2080-241d-11eb-998b-2b321968f398.png)


[GIF is too large for GitHub](https://i.imgur.com/SWZ3AdH.mp4)