### PR TITLE
Prepare app for Windows packaging

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -9,4 +9,6 @@ files:
     filter:
       - package.json
       - app
+      - worker/dist
+      - icon.png
 publish: null

--- a/main/analyzer.ts
+++ b/main/analyzer.ts
@@ -11,14 +11,13 @@ const NUM_WORKERS = Math.ceil(os.cpus().length);
 
 function createWorkerWindow() {
     const window = new BrowserWindow({
-        // show: false,
+        show: false,
         webPreferences: {
             nodeIntegration: true,
         },
     });
 
     window.loadURL(`file://${path.resolve(__dirname, '../worker/dist/index.html')}`);
-    window.webContents.openDevTools();
     return window;
 }
 

--- a/main/background.ts
+++ b/main/background.ts
@@ -27,6 +27,7 @@ if (isProd) {
 
     if (isProd) {
         await mainWindow.loadURL('app://./home.html');
+        mainWindow.setMenuBarVisibility(false);
     } else {
         const port = process.argv[2];
         await mainWindow.loadURL(`http://localhost:${port}/home`);
@@ -39,7 +40,7 @@ app.on('window-all-closed', () => {
 });
 
 protocol.registerSchemesAsPrivileged([
-    { scheme: 'audio', privileges: { standard: true, secure: true, supportFetchAPI: true, corsEnabled: false } },
+    { scheme: 'audio', privileges: { standard: false, secure: true, supportFetchAPI: true, corsEnabled: false } },
 ]);
 
 app.on('ready', async () => {

--- a/main/db/dbFactory.ts
+++ b/main/db/dbFactory.ts
@@ -1,10 +1,8 @@
 import Datastore from 'nedb-promises';
 
-import getAppPath from '../../util/getAppPath';
-
 export default (fileName: string) =>
     Datastore.create({
-        filename: `${getAppPath()}/.data/${fileName}`,
+        filename: `./.data/${fileName}`,
         timestampData: true,
         autoload: true,
     });

--- a/renderer/components/analyzer-status.tsx
+++ b/renderer/components/analyzer-status.tsx
@@ -46,7 +46,7 @@ export default function AnalyzerStatus() {
     } = useAppState();
     const theme = useTheme();
 
-    if (analyzer.tasks.length === 0 || (!analyzer.running && analyzer.errors.length === 0)) {
+    if (!analyzer.latest || (!analyzer.running && analyzer.errors.length === 0)) {
         return null;
     }
 

--- a/renderer/components/select-folder.tsx
+++ b/renderer/components/select-folder.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Button } from 'rebass';
 import styled from '@emotion/styled';
+import path from 'path';
 
 const Hidden = styled.div`
     display: none;
@@ -11,8 +12,9 @@ const SelectFolder = ({ onChange }) => {
         const { files } = e.target;
         const [head] = files;
         if (!head) return;
-        const { path, webkitRelativePath: relPath } = head;
-        const folder = [path.substring(0, path.indexOf(relPath) - 1), relPath.split('/')[0]].join('/');
+        const { path: dir, webkitRelativePath: relPath } = head;
+        const localPath = path.normalize(relPath);
+        const folder = [dir.substring(0, dir.indexOf(localPath) - 1), localPath.split(path.sep)[0]].join(path.sep);
         onChange(folder);
     };
     const onlyFolders = { webkitdirectory: '', multiple: '' };

--- a/util/getFileName.ts
+++ b/util/getFileName.ts
@@ -1,6 +1,8 @@
+import { sep } from 'path';
+
 export default (path) => {
     if (!path) return '';
-    const i = path.lastIndexOf('/');
+    const i = path.lastIndexOf(sep);
     if (i <= -1) return path;
     return path.substring(i + 1, path.length);
 };

--- a/util/getSoundFiles.ts
+++ b/util/getSoundFiles.ts
@@ -6,5 +6,5 @@ import glob from 'glob-promise';
  * @returns an array of sound file names
  */
 export default function getSoundFiles(folder: string): Promise<string[]> {
-    return glob.promise(`${folder}/**/*.{mp3,wav}`, { nocase: true });
+    return glob.promise(`/**/*.{mp3,wav}`, { root: folder || process.cwd(), nocase: true });
 }


### PR DESCRIPTION
Prepares the app for Windows packaging.  Prior to this commit, a few things prevented the app from running on Windows:

- The separators in paths were not normalized by the folder selector to use the correct separator.
- Glob only supports using the forward slash so using a Windows path returned 0 results.  I was able to work around this since it allows Windows paths as the root.
- The custom `audio://` protocol normalized the Windows path to remove colons and backslashes.	This was fixed by making it a non standard protocol.
- The analyzer interestingly returns 0 results for the `tasks` field which caused the progress bar to not show up.  I worked around this by using the latest field instead

To package it the database needed to be stored outside the asar app package.  Additionally the worker needed to be included in this package.

I tested these changes on both Debian and Windows everything seems to work the same.

![soundboy](https://user-images.githubusercontent.com/7284672/101562691-b75d3900-397c-11eb-9730-81ec31b843f0.png)


[Windows package](https://drive.google.com/file/d/1cojTc6ahuUQhqM28QWGkz5DDrBNG0io8/view?usp=sharing)